### PR TITLE
Add CLAUDE.md and CI workflow for Dockerfile linting

### DIFF
--- a/.github/workflows/dockerfile-lint.yml
+++ b/.github/workflows/dockerfile-lint.yml
@@ -1,0 +1,15 @@
+name: Dockerfile Lint
+
+on:
+  pull_request:
+    paths:
+      - 'Dockerfile'
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: hadolint/hadolint-action@v3.1.0
+        with:
+          dockerfile: Dockerfile

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,43 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Docker container for running KeePass2 password manager with X11 display forwarding. Allows running KeePass2 GUI on macOS (and other systems) via an X server like XQuartz.
+
+## Build Commands
+
+```shell
+# Build for ARM64 v8 (default, for Apple Silicon)
+make build
+
+# Build for AMD64
+make build-amd
+
+# Build for ARM64
+make build-arm
+
+# Build and publish multi-arch image to Docker Hub
+make build-pub
+```
+
+## Run Command
+
+```shell
+make run
+```
+
+Required environment variables before running:
+- `IP` - Host IP address (e.g., `export IP=$(ifconfig en1 | grep inet | awk '$1=="inet" {print $2}')`)
+- `KEEPASS_FOLDER` - Path to folder containing the KeePass database file
+
+Optional environment variables:
+- `IMAGE_TAG` - Docker image tag (default: `latest`)
+- `KEEPASS_VAULT` - KeePass database filename (default: `myvault.kdbx`)
+
+## Architecture
+
+- **Dockerfile**: Debian bullseye-slim based image that installs KeePass2 and sets it as the entrypoint
+- **Makefile**: Build targets for different architectures and run configuration
+- X11 forwarding: Container connects to host X server via `DISPLAY` environment variable and `/tmp/.X11-unix` volume mount


### PR DESCRIPTION
## Summary
- Add CLAUDE.md file to provide guidance for Claude Code when working with this repository
- Add GitHub Actions CI workflow to lint Dockerfile using Hadolint on pull requests

## Test plan
- [ ] Verify the Hadolint workflow runs on PRs that modify the Dockerfile
- [ ] Confirm CLAUDE.md provides accurate project documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)