### PR TITLE
Fix X11 forwarding for Docker Desktop on macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,11 +30,12 @@ build-pub:
 	docker buildx stop
 
 run:
-	xhost +${IP}
-	docker run -d --rm --name keepass2 \
-	--net=host \
-	--env DISPLAY=${IP}:0 \
-	--volume /tmp/.X11-unix:/tmp/.X11-unix \
+	xhost +localhost
+	docker run --rm --name keepass2 \
+	--env DISPLAY=host.docker.internal:0 \
+	--env _X11_NO_MITSHM=1 \
+	--env QT_X11_NO_MITSHM=1 \
+	--add-host=host.docker.internal:host-gateway \
 	--volume ${KEEPASS_FOLDER}:/keepass_folder ${IMAGE_NAME} ${KEEPASS_VAULT}
 
 rmi:

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,10 @@
 export IMAGE_NAME=malcata/keepass2
 export KEEPASS_FOLDER?="/tmp"
-export IP?="192.168.100.100"
 export IMAGE_TAG?=latest
 export DOCKER_LOGIN?=malcata
 export KEEPASS_VAULT?=myvault.kdbx
 
-# One should have environment variables setting $IP and $KEEPASS_FOLDER
+# One should have the environment variable $KEEPASS_FOLDER set before running
 
 
 build:


### PR DESCRIPTION
## Summary

- Replace `--net=host` + physical IP display target with `host.docker.internal:0`, which Docker Desktop resolves correctly from inside the container VM
- Add `--add-host=host.docker.internal:host-gateway` to ensure the hostname resolves even without Docker Desktop's automatic injection
- Switch `xhost +${IP}` to `xhost +localhost` so XQuartz accepts connections that arrive via the host-gateway

## Root cause

Docker Desktop on macOS runs containers inside a Linux VM. `--net=host` does not share the Mac's network stack, so containers cannot reach the host's physical IP (`${IP}`) on port 6000. X11 connections were silently failing with "unable to open display".

## Test plan

- [ ] `make run` launches KeePass2 window in XQuartz on macOS (Apple Silicon)
- [ ] No `Authorization required` or `unable to open display` errors in container output

🤖 Generated with [Claude Code](https://claude.com/claude-code)